### PR TITLE
added support for multi-strings in binary strings

### DIFF
--- a/src/main/java/com/metadave/etp/ETP.g4
+++ b/src/main/java/com/metadave/etp/ETP.g4
@@ -58,7 +58,7 @@ etp_tuple:       LCURLY (tupleitems+=etp_term (COMMA tupleitems+=etp_term)*)? RC
 etp_pid:         LESSTHAN PIDID GREATERTHAN | HASH PID LESSTHAN ID GREATERTHAN;
 etp_fun:         HASH FUN LESSTHAN (.)*? GREATERTHAN;
 etp_binary:      BINSTART (segments+=etp_binary_item (COMMA segments+=etp_binary_item)*)? BINEND;
-etp_binary_item: val=INT (COLON size=INT)? | STRING;
+etp_binary_item: val=INT (COLON size=INT)? | (strlines+=STRING ( strlines+=STRING )*)?;
 etp_binary_fake: HASH BIN LESSTHAN size=INT GREATERTHAN;
 
 etp_ref:    HASH REF LESSTHAN REFID GREATERTHAN;

--- a/src/main/java/com/metadave/etp/ETPParser.java
+++ b/src/main/java/com/metadave/etp/ETPParser.java
@@ -899,8 +899,8 @@ public class ETPParser extends Parser {
 			{
 			setState(131); match(BINSTART);
 			setState(140);
-			_la = _input.LA(1);
-			if (_la==INT || _la==STRING) {
+			switch ( getInterpreter().adaptivePredict(_input,11,_ctx) ) {
+			case 1:
 				{
 				setState(132); ((Etp_binaryContext)_localctx).etp_binary_item = etp_binary_item();
 				((Etp_binaryContext)_localctx).segments.add(((Etp_binaryContext)_localctx).etp_binary_item);
@@ -920,8 +920,8 @@ public class ETPParser extends Parser {
 					_la = _input.LA(1);
 				}
 				}
+				break;
 			}
-
 			setState(142); match(BINEND);
 			}
 		}
@@ -939,7 +939,12 @@ public class ETPParser extends Parser {
 	public static class Etp_binary_itemContext extends ParserRuleContext {
 		public Token val;
 		public Token size;
-		public TerminalNode STRING() { return getToken(ETPParser.STRING, 0); }
+		public Token STRING;
+		public List<Token> strlines = new ArrayList<Token>();
+		public List<TerminalNode> STRING() { return getTokens(ETPParser.STRING); }
+		public TerminalNode STRING(int i) {
+			return getToken(ETPParser.STRING, i);
+		}
 		public TerminalNode COLON() { return getToken(ETPParser.COLON, 0); }
 		public TerminalNode INT(int i) {
 			return getToken(ETPParser.INT, i);
@@ -964,7 +969,7 @@ public class ETPParser extends Parser {
 		enterRule(_localctx, 28, RULE_etp_binary_item);
 		int _la;
 		try {
-			setState(150);
+			setState(158);
 			switch (_input.LA(1)) {
 			case INT:
 				enterOuterAlt(_localctx, 1);
@@ -981,10 +986,34 @@ public class ETPParser extends Parser {
 
 				}
 				break;
+			case COMMA:
+			case BINEND:
 			case STRING:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(149); match(STRING);
+				setState(156);
+				_la = _input.LA(1);
+				if (_la==STRING) {
+					{
+					setState(149); ((Etp_binary_itemContext)_localctx).STRING = match(STRING);
+					((Etp_binary_itemContext)_localctx).strlines.add(((Etp_binary_itemContext)_localctx).STRING);
+					setState(153);
+					_errHandler.sync(this);
+					_la = _input.LA(1);
+					while (_la==STRING) {
+						{
+						{
+						setState(150); ((Etp_binary_itemContext)_localctx).STRING = match(STRING);
+						((Etp_binary_itemContext)_localctx).strlines.add(((Etp_binary_itemContext)_localctx).STRING);
+						}
+						}
+						setState(155);
+						_errHandler.sync(this);
+						_la = _input.LA(1);
+					}
+					}
+				}
+
 				}
 				break;
 			default:
@@ -1029,11 +1058,11 @@ public class ETPParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(152); match(HASH);
-			setState(153); match(BIN);
-			setState(154); match(LESSTHAN);
-			setState(155); ((Etp_binary_fakeContext)_localctx).size = match(INT);
-			setState(156); match(GREATERTHAN);
+			setState(160); match(HASH);
+			setState(161); match(BIN);
+			setState(162); match(LESSTHAN);
+			setState(163); ((Etp_binary_fakeContext)_localctx).size = match(INT);
+			setState(164); match(GREATERTHAN);
 			}
 		}
 		catch (RecognitionException re) {
@@ -1073,11 +1102,11 @@ public class ETPParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(158); match(HASH);
-			setState(159); match(REF);
-			setState(160); match(LESSTHAN);
-			setState(161); match(REFID);
-			setState(162); match(GREATERTHAN);
+			setState(166); match(HASH);
+			setState(167); match(REF);
+			setState(168); match(LESSTHAN);
+			setState(169); match(REFID);
+			setState(170); match(GREATERTHAN);
 			}
 		}
 		catch (RecognitionException re) {
@@ -1092,7 +1121,7 @@ public class ETPParser extends Parser {
 	}
 
 	public static final String _serializedATN =
-		"\2\3\37\u00a7\4\2\t\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b"+
+		"\2\3\37\u00af\4\2\t\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b"+
 		"\4\t\t\t\4\n\t\n\4\13\t\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t"+
 		"\20\4\21\t\21\4\22\t\22\3\2\3\2\3\2\6\2(\n\2\r\2\16\2)\3\3\3\3\3\3\3\3"+
 		"\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\5\39\n\3\3\4\3\4\3\5\3\5\3\6\3\6"+
@@ -1102,43 +1131,46 @@ public class ETPParser extends Parser {
 		"\n\f\3\f\3\f\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\5\ry\n\r\3\16\3\16\3\16\3"+
 		"\16\7\16\177\n\16\f\16\16\16\u0082\13\16\3\16\3\16\3\17\3\17\3\17\3\17"+
 		"\7\17\u008a\n\17\f\17\16\17\u008d\13\17\5\17\u008f\n\17\3\17\3\17\3\20"+
-		"\3\20\3\20\5\20\u0096\n\20\3\20\5\20\u0099\n\20\3\21\3\21\3\21\3\21\3"+
-		"\21\3\21\3\22\3\22\3\22\3\22\3\22\3\22\3\22\3\u0080\23\2\4\6\b\n\f\16"+
-		"\20\22\24\26\30\32\34\36 \"\2\4\3\27\30\3\22\23\u00ae\2\'\3\2\2\2\48\3"+
-		"\2\2\2\6:\3\2\2\2\b<\3\2\2\2\n>\3\2\2\2\f@\3\2\2\2\16B\3\2\2\2\20D\3\2"+
-		"\2\2\22R\3\2\2\2\24V\3\2\2\2\26c\3\2\2\2\30x\3\2\2\2\32z\3\2\2\2\34\u0085"+
-		"\3\2\2\2\36\u0098\3\2\2\2 \u009a\3\2\2\2\"\u00a0\3\2\2\2$%\5\4\3\2%&\7"+
-		"\26\2\2&(\3\2\2\2\'$\3\2\2\2()\3\2\2\2)\'\3\2\2\2)*\3\2\2\2*\3\3\2\2\2"+
-		"+9\5\f\7\2,9\5\6\4\2-9\5\b\5\2.9\5\n\6\2/9\5\16\b\2\609\5\24\13\2\619"+
-		"\5\26\f\2\629\5\20\t\2\639\5\34\17\2\649\5 \21\2\659\5\30\r\2\669\5\32"+
-		"\16\2\679\5\"\22\28+\3\2\2\28,\3\2\2\28-\3\2\2\28.\3\2\2\28/\3\2\2\28"+
-		"\60\3\2\2\28\61\3\2\2\28\62\3\2\2\28\63\3\2\2\28\64\3\2\2\28\65\3\2\2"+
-		"\28\66\3\2\2\28\67\3\2\2\29\5\3\2\2\2:;\7\31\2\2;\7\3\2\2\2<=\7\32\2\2"+
-		"=\t\3\2\2\2>?\7\35\2\2?\13\3\2\2\2@A\t\2\2\2A\r\3\2\2\2BC\t\3\2\2C\17"+
-		"\3\2\2\2DE\7\25\2\2EN\7\13\2\2FK\5\22\n\2GH\7\7\2\2HJ\5\22\n\2IG\3\2\2"+
-		"\2JM\3\2\2\2KI\3\2\2\2KL\3\2\2\2LO\3\2\2\2MK\3\2\2\2NF\3\2\2\2NO\3\2\2"+
-		"\2OP\3\2\2\2PQ\7\f\2\2Q\21\3\2\2\2RS\5\4\3\2ST\7\n\2\2TU\5\4\3\2U\23\3"+
-		"\2\2\2V_\7\b\2\2W\\\5\4\3\2XY\7\7\2\2Y[\5\4\3\2ZX\3\2\2\2[^\3\2\2\2\\"+
-		"Z\3\2\2\2\\]\3\2\2\2]`\3\2\2\2^\\\3\2\2\2_W\3\2\2\2_`\3\2\2\2`a\3\2\2"+
-		"\2ab\7\t\2\2b\25\3\2\2\2cl\7\13\2\2di\5\4\3\2ef\7\7\2\2fh\5\4\3\2ge\3"+
-		"\2\2\2hk\3\2\2\2ig\3\2\2\2ij\3\2\2\2jm\3\2\2\2ki\3\2\2\2ld\3\2\2\2lm\3"+
-		"\2\2\2mn\3\2\2\2no\7\f\2\2o\27\3\2\2\2pq\7\r\2\2qr\7\33\2\2ry\7\16\2\2"+
-		"st\7\25\2\2tu\7\5\2\2uv\7\r\2\2vw\7\27\2\2wy\7\16\2\2xp\3\2\2\2xs\3\2"+
-		"\2\2y\31\3\2\2\2z{\7\25\2\2{|\7\3\2\2|\u0080\7\r\2\2}\177\13\2\2\2~}\3"+
-		"\2\2\2\177\u0082\3\2\2\2\u0080\u0081\3\2\2\2\u0080~\3\2\2\2\u0081\u0083"+
-		"\3\2\2\2\u0082\u0080\3\2\2\2\u0083\u0084\7\16\2\2\u0084\33\3\2\2\2\u0085"+
-		"\u008e\7\20\2\2\u0086\u008b\5\36\20\2\u0087\u0088\7\7\2\2\u0088\u008a"+
-		"\5\36\20\2\u0089\u0087\3\2\2\2\u008a\u008d\3\2\2\2\u008b\u0089\3\2\2\2"+
-		"\u008b\u008c\3\2\2\2\u008c\u008f\3\2\2\2\u008d\u008b\3\2\2\2\u008e\u0086"+
-		"\3\2\2\2\u008e\u008f\3\2\2\2\u008f\u0090\3\2\2\2\u0090\u0091\7\21\2\2"+
-		"\u0091\35\3\2\2\2\u0092\u0095\7\31\2\2\u0093\u0094\7\17\2\2\u0094\u0096"+
-		"\7\31\2\2\u0095\u0093\3\2\2\2\u0095\u0096\3\2\2\2\u0096\u0099\3\2\2\2"+
-		"\u0097\u0099\7\35\2\2\u0098\u0092\3\2\2\2\u0098\u0097\3\2\2\2\u0099\37"+
-		"\3\2\2\2\u009a\u009b\7\25\2\2\u009b\u009c\7\6\2\2\u009c\u009d\7\r\2\2"+
-		"\u009d\u009e\7\31\2\2\u009e\u009f\7\16\2\2\u009f!\3\2\2\2\u00a0\u00a1"+
-		"\7\25\2\2\u00a1\u00a2\7\4\2\2\u00a2\u00a3\7\r\2\2\u00a3\u00a4\7\34\2\2"+
-		"\u00a4\u00a5\7\16\2\2\u00a5#\3\2\2\2\20)8KN\\_ilx\u0080\u008b\u008e\u0095"+
-		"\u0098";
+		"\3\20\3\20\5\20\u0096\n\20\3\20\3\20\7\20\u009a\n\20\f\20\16\20\u009d"+
+		"\13\20\5\20\u009f\n\20\5\20\u00a1\n\20\3\21\3\21\3\21\3\21\3\21\3\21\3"+
+		"\22\3\22\3\22\3\22\3\22\3\22\3\22\3\u0080\23\2\4\6\b\n\f\16\20\22\24\26"+
+		"\30\32\34\36 \"\2\4\3\27\30\3\22\23\u00b8\2\'\3\2\2\2\48\3\2\2\2\6:\3"+
+		"\2\2\2\b<\3\2\2\2\n>\3\2\2\2\f@\3\2\2\2\16B\3\2\2\2\20D\3\2\2\2\22R\3"+
+		"\2\2\2\24V\3\2\2\2\26c\3\2\2\2\30x\3\2\2\2\32z\3\2\2\2\34\u0085\3\2\2"+
+		"\2\36\u00a0\3\2\2\2 \u00a2\3\2\2\2\"\u00a8\3\2\2\2$%\5\4\3\2%&\7\26\2"+
+		"\2&(\3\2\2\2\'$\3\2\2\2()\3\2\2\2)\'\3\2\2\2)*\3\2\2\2*\3\3\2\2\2+9\5"+
+		"\f\7\2,9\5\6\4\2-9\5\b\5\2.9\5\n\6\2/9\5\16\b\2\609\5\24\13\2\619\5\26"+
+		"\f\2\629\5\20\t\2\639\5\34\17\2\649\5 \21\2\659\5\30\r\2\669\5\32\16\2"+
+		"\679\5\"\22\28+\3\2\2\28,\3\2\2\28-\3\2\2\28.\3\2\2\28/\3\2\2\28\60\3"+
+		"\2\2\28\61\3\2\2\28\62\3\2\2\28\63\3\2\2\28\64\3\2\2\28\65\3\2\2\28\66"+
+		"\3\2\2\28\67\3\2\2\29\5\3\2\2\2:;\7\31\2\2;\7\3\2\2\2<=\7\32\2\2=\t\3"+
+		"\2\2\2>?\7\35\2\2?\13\3\2\2\2@A\t\2\2\2A\r\3\2\2\2BC\t\3\2\2C\17\3\2\2"+
+		"\2DE\7\25\2\2EN\7\13\2\2FK\5\22\n\2GH\7\7\2\2HJ\5\22\n\2IG\3\2\2\2JM\3"+
+		"\2\2\2KI\3\2\2\2KL\3\2\2\2LO\3\2\2\2MK\3\2\2\2NF\3\2\2\2NO\3\2\2\2OP\3"+
+		"\2\2\2PQ\7\f\2\2Q\21\3\2\2\2RS\5\4\3\2ST\7\n\2\2TU\5\4\3\2U\23\3\2\2\2"+
+		"V_\7\b\2\2W\\\5\4\3\2XY\7\7\2\2Y[\5\4\3\2ZX\3\2\2\2[^\3\2\2\2\\Z\3\2\2"+
+		"\2\\]\3\2\2\2]`\3\2\2\2^\\\3\2\2\2_W\3\2\2\2_`\3\2\2\2`a\3\2\2\2ab\7\t"+
+		"\2\2b\25\3\2\2\2cl\7\13\2\2di\5\4\3\2ef\7\7\2\2fh\5\4\3\2ge\3\2\2\2hk"+
+		"\3\2\2\2ig\3\2\2\2ij\3\2\2\2jm\3\2\2\2ki\3\2\2\2ld\3\2\2\2lm\3\2\2\2m"+
+		"n\3\2\2\2no\7\f\2\2o\27\3\2\2\2pq\7\r\2\2qr\7\33\2\2ry\7\16\2\2st\7\25"+
+		"\2\2tu\7\5\2\2uv\7\r\2\2vw\7\27\2\2wy\7\16\2\2xp\3\2\2\2xs\3\2\2\2y\31"+
+		"\3\2\2\2z{\7\25\2\2{|\7\3\2\2|\u0080\7\r\2\2}\177\13\2\2\2~}\3\2\2\2\177"+
+		"\u0082\3\2\2\2\u0080\u0081\3\2\2\2\u0080~\3\2\2\2\u0081\u0083\3\2\2\2"+
+		"\u0082\u0080\3\2\2\2\u0083\u0084\7\16\2\2\u0084\33\3\2\2\2\u0085\u008e"+
+		"\7\20\2\2\u0086\u008b\5\36\20\2\u0087\u0088\7\7\2\2\u0088\u008a\5\36\20"+
+		"\2\u0089\u0087\3\2\2\2\u008a\u008d\3\2\2\2\u008b\u0089\3\2\2\2\u008b\u008c"+
+		"\3\2\2\2\u008c\u008f\3\2\2\2\u008d\u008b\3\2\2\2\u008e\u0086\3\2\2\2\u008e"+
+		"\u008f\3\2\2\2\u008f\u0090\3\2\2\2\u0090\u0091\7\21\2\2\u0091\35\3\2\2"+
+		"\2\u0092\u0095\7\31\2\2\u0093\u0094\7\17\2\2\u0094\u0096\7\31\2\2\u0095"+
+		"\u0093\3\2\2\2\u0095\u0096\3\2\2\2\u0096\u00a1\3\2\2\2\u0097\u009b\7\35"+
+		"\2\2\u0098\u009a\7\35\2\2\u0099\u0098\3\2\2\2\u009a\u009d\3\2\2\2\u009b"+
+		"\u0099\3\2\2\2\u009b\u009c\3\2\2\2\u009c\u009f\3\2\2\2\u009d\u009b\3\2"+
+		"\2\2\u009e\u0097\3\2\2\2\u009e\u009f\3\2\2\2\u009f\u00a1\3\2\2\2\u00a0"+
+		"\u0092\3\2\2\2\u00a0\u009e\3\2\2\2\u00a1\37\3\2\2\2\u00a2\u00a3\7\25\2"+
+		"\2\u00a3\u00a4\7\6\2\2\u00a4\u00a5\7\r\2\2\u00a5\u00a6\7\31\2\2\u00a6"+
+		"\u00a7\7\16\2\2\u00a7!\3\2\2\2\u00a8\u00a9\7\25\2\2\u00a9\u00aa\7\4\2"+
+		"\2\u00aa\u00ab\7\r\2\2\u00ab\u00ac\7\34\2\2\u00ac\u00ad\7\16\2\2\u00ad"+
+		"#\3\2\2\2\22)8KN\\_ilx\u0080\u008b\u008e\u0095\u009b\u009e\u00a0";
 	public static final ATN _ATN =
 		ATNSimulator.deserialize(_serializedATN.toCharArray());
 	static {

--- a/src/main/java/com/metadave/etp/ETPWalker.java
+++ b/src/main/java/com/metadave/etp/ETPWalker.java
@@ -196,12 +196,15 @@ public class ETPWalker extends ETPBaseListener {
             } else {
                 v = new ETPBinary.BinInt(Long.parseLong(ctx.val.getText()));
             }
-        } else if (ctx.STRING() != null) {
+        } else if (ctx.strlines.size()>0) {
+            StringBuilder s=new StringBuilder();
+            for(Token x : ctx.strlines) {
+                s.append(stripQuotes(x.getText()));
+            }
             if (ctx.size != null) {
-                v = new ETPBinary.BinString(stripQuotes(ctx.STRING().getText()),
-                        Integer.parseInt(ctx.size.getText()));
+                v = new ETPBinary.BinString(s.toString(),Integer.parseInt(ctx.size.getText()));
             } else {
-                v = new ETPBinary.BinString(stripQuotes(ctx.STRING().getText()));
+                v = new ETPBinary.BinString(s.toString());
             }
         }
         setValue(ctx, v);

--- a/src/main/java/com/metadave/etp/rep/ETPBinary.java
+++ b/src/main/java/com/metadave/etp/rep/ETPBinary.java
@@ -62,6 +62,12 @@ public class ETPBinary extends ETPTerm<List<ETPBinary.ETPBinaryValue>> {
         return b.toString();
     }
 
+    public String quote(String s) {
+        s=s.replace("\\","\\\\");
+        s=s.replace("\"","\\\"");
+        return s;
+    }
+
     @Override
     public OtpErlangObject getOTP() {
         return null;
@@ -127,7 +133,13 @@ public class ETPBinary extends ETPTerm<List<ETPBinary.ETPBinaryValue>> {
 
         @Override
         public String toString() {
-            return "\"" + value + "\"";
+            return "\"" + quote(value) + "\"";
+        }
+
+        public String quote(String s) {
+            s=s.replace("\\","\\\\");
+            s=s.replace("\"","\\\"");
+            return s;
         }
 
         @Override

--- a/src/test/java/com/metadave/etp/TestETP.java
+++ b/src/test/java/com/metadave/etp/TestETP.java
@@ -23,8 +23,10 @@ package com.metadave.etp;
 
 import com.ericsson.otp.erlang.*;
 import com.metadave.etp.rep.*;
+import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -261,6 +263,22 @@ public class TestETP {
             assertEquals(new ETPLong(2), t.getValue().get(new ETPString("b")));
             assertEquals(new ETPLong(4), t.getValue().get(new ETPString("c")));
         }
+    }
+
+    @Test
+    public void testMulti() throws Exception {
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("test.app.src").getFile());
+        ETPTerm<HashMap<ETPTerm<?>, ETPTerm<?>>> t = ETP.parse(FileUtils.readFileToString(file,"utf-8"));
+        String s=t.toString();
+        assertEquals("{application,aaaa,[{description,\"Some description\"},{vsn,\"1.1.1\"},{registered,[]},{applications,[kernel,stdlib,recon]},{mod,{aaaa,[]}},{env,[{fun1,<<\"fun (M) ->File = \\\"/var/opt/mpro/log/mpro.mon\\\",Format =\\\"processes:~p~n\\\"\\\"maxpqueue:~p~n\\\",end\">>}]}]}",s);
+    }
+
+    @Test
+    public void testMulti2() throws Exception {
+        ETPTerm t = ETP.parse("<<\"a \\\"b\\\"\"\n \"c\">>");
+        String s=t.toString();
+        assertEquals("<<\"a \\\"b\\\"c\">>",s);
     }
 
 

--- a/src/test/resources/test.app.src
+++ b/src/test/resources/test.app.src
@@ -1,0 +1,23 @@
+%% -*- mode: erlang -*-
+%% ex: ft=erlang
+{application, aaaa, [
+    {description, "Some description"},
+    {vsn, "1.1.1"},
+    {registered, []},
+    {applications,
+     [kernel,
+      stdlib,
+      recon
+     ]},
+    {mod, {aaaa, []}},
+    {env, [
+           {fun1,
+            <<"fun (M) ->"
+              "File = \"/var/opt/mpro/log/mpro.mon\","
+              "Format =\"processes:~p~n\""
+              "\"maxpqueue:~p~n\""
+              ","
+              "end">>}
+          ]}
+    ]
+}.


### PR DESCRIPTION
I had a problem parsing erlang terms file as in src/test/resources/test.app.src. 
The problem was with multi string notation. 
Also when printing binary string,  \ and " chars inside the string are not escaped. 
